### PR TITLE
Adding of a guide for bitcoin compiling on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project is available **[HERE](https://madein.galsendev.com/)** 🚀
 
 - **[Basics Frontend Components Collections](https://github.com/daoodaba975/basics-frontend-components-collections)** - This is a large collections of some basics frontend components crafted with HTML, CSS & JavaScript only, ready to be used. **by [@daoodaba975](https://github.com/daoodaba975)**
 - **[Blockchain Programming Golang](https://github.com/diop/blockchain-programming-golang)** - Blockchain Programming in Go. **by [@diop](https://github.com/diop)**
+- **[Bitcoin Compiling and Test Running on WSL](https://github.com/nourou4them/bitcoinsn)** - Installing WSL (Ubuntu here) on a non-system drive, compile bitcoin source code and run tests (units, regression nd functional). **by [@nourou4them](https://github.com/nourou4them)**
 
 ## <a name="C"> </a>C
 


### PR DESCRIPTION
While installing the wsl the classic way, we could not be able to build bitcoin due to a lack of space in the C:\ drive.
That would also make impossible to run tests (units, regression and functional).
That's why it may be important to install WSL on a non-system drive in order to compile bitcoin core.